### PR TITLE
Using tags rather than indexes for $quotes

### DIFF
--- a/config.js
+++ b/config.js
@@ -61,35 +61,25 @@ module.exports = {
   quotes: [
     {
       key: 'loli',
-      quote: 'C\'est parce que c\'est pas du loli rape',
-      author: 'kiniamaro',
-      timestamp: 2014
+      quote: '"C\'est parce que c\'est pas du loli rape" -kiniamaro 2014',
     }, {
       key: 'mac',
-      quote: 'ouais, I\'m not letting it die, c\'est mon dernier mac à vie',
-      author: 'alxgnon',
-      timestamp: 2014
+      quote: '"ouais, I\'m not letting it die, c\'est mon dernier mac à vie" -alxgnon 2014'
     }, {
       key: 'arch',
-      quote: 'Check ben comment j\'installe Arch en 30 minutes!',
-      author: 'MrJudgemental',
-      timestamp: 2014
+      quote: '"Check ben comment j\'installe Arch en 30 minutes!" -MrJudgemental 2014'
     }, {
       key: 'biblio',
-      quote: 'En arrière de la biblio municipale',
-      author: 'SBSTP',
-      timestamp: 2014
+      quote: '"En arrière de la biblio municipale" -SBSTP 2014',
     }, {
       key: 'broken',
-      quote: 'The bot is broken',
-      author: 'everyone',
-      timestamp: 2014
+      quote: 'The bot is broken! -everyone 2014',
     }, {
       key: 'rodric',
-      link: 'http://i.imgur.com/0CW6W7t.jpg'
+      quote: 'http://i.imgur.com/0CW6W7t.jpg'
     }, {
       key: 'lookingformaniac',
-      link: 'http://pastebin.com/BrtTPvXT'
+      quote: 'http://pastebin.com/BrtTPvXT'
     }
   ],
 };

--- a/plugins/quotes.js
+++ b/plugins/quotes.js
@@ -33,13 +33,10 @@ module.exports = function (core) {
   
   function sayQuote (quoteObject) {
     if(quoteObject.hasOwnProperty('quote')) {
-      core.irc.sayFmt('"%s" -%s, %s', quoteObject.quote, quoteObject.author,
-          quoteObject.timestamp);
-    } else if(quoteObject.hasOwnProperty('link')) {
-      core.irc.sayPub(quoteObject.link);
+      core.irc.sayPub(quoteObject.quote);
     } else {
-      core.irc.sayFmt('An entry tagged "%s" exists, but is neither a quote or' +
-          ' a link.', quoteObject.tag);
+      core.irc.sayFmt('An entry tagged "%s" exists, but does not have' +
+          ' any text associated with it.', quoteObject.tag);
     }
     
   }


### PR DESCRIPTION
This serves to alleviate the confusion when looking for a quote in our still small quote catalog.
